### PR TITLE
Add Excel workbook support for verse splitting

### DIFF
--- a/README_split_verses.md
+++ b/README_split_verses.md
@@ -6,6 +6,7 @@ A tiny command‑line tool to cut an audio file into verse segments.
 ## Requirements
 - Python 3.9+
 - `pydub`
+- `openpyxl` (only required when reading Excel timestamp files)
 - `ffmpeg` installed and available on your PATH
 
 Install Python deps:
@@ -65,6 +66,22 @@ Then run:
 ```bash
 python split_verses.py -i input.mp3 -o out --timestamps cuts.csv --prefix "Verse_" --zip --csv out/timings.csv
 ```
+
+## Excel Workbook Mode
+If your timestamps live in an Excel workbook (one sheet per chapter) with columns like:
+
+| Chapter Sloka | Beginning | Ending |
+|---------------|-----------|--------|
+| Intro         | 0         | 0.30   |
+| 12.01         | 0.30      | 0.45   |
+
+Run:
+
+```bash
+python split_verses.py -i input.mp3 -o out --timestamps-excel chapters.xlsx --zip --csv out/timings.csv
+```
+
+Each sheet is exported to its own subdirectory (named after the sheet). File names follow the "Chapter Sloka" values (`Intro.mp3`, `12.01.mp3`, etc.).
 
 ## Options
 - `--start`   : start offset (seconds or mm:ss), default `0`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pydub>=0.25.1
+openpyxl>=3.1.2

--- a/split_verses.py
+++ b/split_verses.py
@@ -15,8 +15,26 @@ Requires: Python 3.9+, pydub, and ffmpeg installed & on PATH.
 import argparse
 import csv
 import os
-from typing import List, Tuple, Optional
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta
+from typing import Dict, List, Optional, Tuple
 from pydub import AudioSegment
+
+try:
+    from openpyxl import load_workbook
+except ImportError:  # pragma: no cover - optional dependency
+    load_workbook = None
+
+
+@dataclass
+class Segment:
+    label: str
+    start_ms: int
+    end_ms: int
+
+    @property
+    def duration_ms(self) -> int:
+        return max(0, self.end_ms - self.start_ms)
 import zipfile
 
 def parse_time(s: str) -> int:
@@ -45,6 +63,22 @@ def mmss(ms: int) -> str:
     sec = s % 60
     return f"{m:02d}:{sec:02d}"
 
+
+def sanitize_filename(name: str, fallback: str) -> str:
+    base = name.strip() if name else ""
+    allowed = []
+    for ch in base:
+        if ch.isalnum() or ch in ("_", "-", "."):
+            allowed.append(ch)
+        elif ch.isspace():
+            allowed.append("_")
+    cleaned = "".join(allowed).strip("._")
+    return cleaned or fallback
+
+
+def normalize_header(cell: str) -> str:
+    return "".join(ch for ch in cell.lower() if ch.isalnum())
+
 def grid_cuts(start_ms: int, count: int, length_ms: int, total_ms: int) -> List[Tuple[int, int]]:
     cuts = []
     for i in range(count):
@@ -57,6 +91,130 @@ def grid_cuts(start_ms: int, count: int, length_ms: int, total_ms: int) -> List[
         cuts.append((st, en))
     return cuts
 
+
+def parse_excel_time(value) -> int:
+    """Parse the Excel "Beginning"/"Ending" cell into milliseconds."""
+
+    def minutes_seconds_from_string(text: str) -> Tuple[int, int]:
+        text = text.strip()
+        if not text:
+            raise ValueError("Empty time value")
+        if ":" in text:
+            return divmod(parse_time(text), 1000)
+        if "." in text:
+            minutes_str, seconds_str = text.split(".", 1)
+            minutes = int(minutes_str) if minutes_str else 0
+            seconds_digits = ''.join(ch for ch in seconds_str if ch.isdigit())
+            if not seconds_digits:
+                seconds = 0
+            elif len(seconds_digits) == 1:
+                seconds = int(seconds_digits) * 10
+            else:
+                seconds = int(seconds_digits[:2])
+            seconds = max(0, min(seconds, 59))
+            return minutes * 60 + seconds, 0
+        # Plain number — treat as minutes (float allowed)
+        minutes_float = float(text)
+        total_seconds = int(round(minutes_float * 60))
+        return total_seconds, 0
+
+    if value is None:
+        raise ValueError("Missing time value in Excel sheet")
+
+    if isinstance(value, timedelta):
+        total_seconds = value.total_seconds()
+        return int(round(total_seconds * 1000))
+
+    if isinstance(value, time):
+        total_seconds = value.hour * 3600 + value.minute * 60 + value.second + value.microsecond / 1_000_000
+        return int(round(total_seconds * 1000))
+
+    if isinstance(value, datetime):
+        total_seconds = value.hour * 3600 + value.minute * 60 + value.second + value.microsecond / 1_000_000
+        return int(round(total_seconds * 1000))
+
+    text_value = str(value).strip()
+    if not text_value:
+        raise ValueError("Empty time value in Excel sheet")
+
+    seconds_or_ms, remainder = minutes_seconds_from_string(text_value)
+    if remainder == 0:
+        total_seconds = seconds_or_ms
+    else:
+        total_seconds = seconds_or_ms + remainder / 1000.0
+    return int(round(total_seconds * 1000))
+
+
+def clamp_segment(start_ms: int, end_ms: int, total_ms: int) -> Tuple[int, int]:
+    st = max(0, min(start_ms, total_ms))
+    en = max(0, min(end_ms, total_ms))
+    return st, en
+
+
+def load_timestamps_excel(path: str, total_ms: int) -> Dict[str, List[Segment]]:
+    if load_workbook is None:
+        raise SystemExit(
+            "openpyxl is required to read Excel timestamp files. Install it with `pip install openpyxl`."
+        )
+
+    wb = load_workbook(path, data_only=True)
+    chapters: Dict[str, List[Segment]] = {}
+
+    for ws in wb.worksheets:
+        rows_iter = ws.iter_rows(values_only=True)
+        header_row: Optional[Tuple] = None
+        for row in rows_iter:
+            if row and any(cell is not None and str(cell).strip() for cell in row):
+                header_row = row
+                break
+        if header_row is None:
+            continue
+
+        headers = [normalize_header(str(cell)) if cell is not None else "" for cell in header_row]
+        idx_label = None
+        idx_begin = None
+        idx_end = None
+        for idx, header in enumerate(headers):
+            if idx_label is None and header in {"chaptersloka", "verse", "sloka", "name", "label"}:
+                idx_label = idx
+            if idx_begin is None and header in {"beginning", "begin", "start"}:
+                idx_begin = idx
+            if idx_end is None and header in {"ending", "end", "finish"}:
+                idx_end = idx
+        if idx_label is None or idx_begin is None or idx_end is None:
+            raise ValueError(
+                f"Sheet '{ws.title}' must contain 'Chapter Sloka', 'Beginning', and 'Ending' columns."
+            )
+
+        segments: List[Segment] = []
+        for row in rows_iter:
+            if not row:
+                continue
+            label_cell = row[idx_label] if idx_label < len(row) else None
+            start_cell = row[idx_begin] if idx_begin < len(row) else None
+            end_cell = row[idx_end] if idx_end < len(row) else None
+
+            if label_cell is None or str(label_cell).strip() == "":
+                continue
+            if start_cell is None or end_cell is None:
+                continue
+
+            st = parse_excel_time(start_cell)
+            en = parse_excel_time(end_cell)
+            st, en = clamp_segment(st, en, total_ms)
+            if en <= st:
+                continue
+            label = str(label_cell).strip()
+            segments.append(Segment(label=label, start_ms=st, end_ms=en))
+
+        if segments:
+            segments.sort(key=lambda seg: seg.start_ms)
+            chapters[ws.title] = segments
+
+    if not chapters:
+        raise ValueError("No usable data found in Excel file.")
+
+    return chapters
 def load_timestamps_csv(path: str, total_ms: int) -> List[Tuple[int,int]]:
     """
     CSV with either headers or not. Expect either:
@@ -70,9 +228,6 @@ def load_timestamps_csv(path: str, total_ms: int) -> List[Tuple[int,int]]:
         reader = csv.reader(f)
         rows = list(reader)
     # try to detect header
-    def normalize_header(cell: str) -> str:
-        return ''.join(ch for ch in cell.lower() if ch.isalnum())
-
     def find_column(header_norm: List[str], keywords: Tuple[str, ...]) -> Optional[int]:
         for idx, norm in enumerate(header_norm):
             for kw in keywords:
@@ -141,6 +296,11 @@ def main():
     ap.add_argument("--count", type=int, default=20, help="Number of verses to cut (grid mode)")
     ap.add_argument("--length", default="15", help="Verse length (seconds or mm:ss) in grid mode")
     ap.add_argument("--timestamps", help="CSV of custom cuts: start,end or start,duration (overrides grid)")
+    ap.add_argument(
+        "--timestamps-excel",
+        dest="timestamps_excel",
+        help="Excel workbook with one sheet per chapter (Chapter Sloka / Beginning / Ending)",
+    )
     ap.add_argument("--prefix", default="Verse_", help="Filename prefix, default Verse_")
     ap.add_argument("--bitrate", default="192k", help="Output bitrate for mp3, default 192k")
     ap.add_argument("--fade_in", type=int, default=5, help="Fade in ms, default 5")
@@ -154,39 +314,101 @@ def main():
     audio = AudioSegment.from_file(args.input)
     total_ms = len(audio)
 
-    if args.timestamps:
+    if args.timestamps and args.timestamps_excel:
+        raise SystemExit("Please provide only one of --timestamps or --timestamps-excel, not both.")
+
+    export_paths: List[str] = []
+    csv_rows: List[Tuple] = []
+    csv_header: Optional[List[str]] = None
+
+    if args.timestamps_excel:
+        chapters = load_timestamps_excel(args.timestamps_excel, total_ms)
+        used_dirnames: Dict[str, int] = {}
+
+        for sheet_name, segments in chapters.items():
+            base_dirname = sanitize_filename(sheet_name, "chapter")
+            count = used_dirnames.get(base_dirname, 0)
+            if count:
+                dirname = f"{base_dirname}_{count+1}"
+            else:
+                dirname = base_dirname
+            used_dirnames[base_dirname] = count + 1
+
+            sheet_dir = os.path.join(args.output, dirname)
+            os.makedirs(sheet_dir, exist_ok=True)
+
+            for idx, seg in enumerate(segments, start=1):
+                fallback_name = f"{args.prefix}{idx:02d}"
+                base_fname = sanitize_filename(seg.label, fallback_name)
+                fname = f"{base_fname}.mp3"
+                fpath = os.path.join(sheet_dir, fname)
+                suffix = 2
+                while os.path.exists(fpath):
+                    fname = f"{base_fname}_{suffix}.mp3"
+                    fpath = os.path.join(sheet_dir, fname)
+                    suffix += 1
+
+                seg_audio = audio[seg.start_ms:seg.end_ms].fade_in(args.fade_in).fade_out(args.fade_out)
+                seg_audio.export(fpath, format="mp3", bitrate=args.bitrate)
+                export_paths.append(fpath)
+
+                csv_rows.append(
+                    (
+                        sheet_name,
+                        seg.label,
+                        mmss(seg.start_ms),
+                        mmss(seg.end_ms),
+                        round(seg.duration_ms / 1000, 3),
+                        os.path.relpath(fpath, args.output),
+                    )
+                )
+
+        csv_header = ["Chapter", "Verse", "Start", "End", "Duration(s)", "File"]
+
+    elif args.timestamps:
         cuts = load_timestamps_csv(args.timestamps, total_ms)
         if not cuts:
             raise SystemExit("No valid cuts parsed from timestamps CSV.")
+        for idx, (st, en) in enumerate(cuts, start=1):
+            seg = audio[st:en].fade_in(args.fade_in).fade_out(args.fade_out)
+            fname = f"{args.prefix}{idx:02d}.mp3"
+            fpath = os.path.join(args.output, fname)
+            seg.export(fpath, format="mp3", bitrate=args.bitrate)
+            export_paths.append(fpath)
+            csv_rows.append((idx, mmss(st), mmss(en), round(len(seg)/1000, 3), fname))
+
+        csv_header = ["Verse", "Start", "End", "Duration(s)", "File"]
+
     else:
         start_ms = parse_time(args.start)
         length_ms = parse_time(args.length)
         cuts = grid_cuts(start_ms, args.count, length_ms, total_ms)
         if not cuts:
             raise SystemExit("No valid cuts produced by grid. Check --start/--count/--length.")
+        for idx, (st, en) in enumerate(cuts, start=1):
+            seg = audio[st:en].fade_in(args.fade_in).fade_out(args.fade_out)
+            fname = f"{args.prefix}{idx:02d}.mp3"
+            fpath = os.path.join(args.output, fname)
+            seg.export(fpath, format="mp3", bitrate=args.bitrate)
+            export_paths.append(fpath)
+            csv_rows.append((idx, mmss(st), mmss(en), round(len(seg)/1000, 3), fname))
 
-    rows = []
-    export_paths = []
-    for idx, (st, en) in enumerate(cuts, start=1):
-        seg = audio[st:en].fade_in(args.fade_in).fade_out(args.fade_out)
-        fname = f"{args.prefix}{idx:02d}.mp3"
-        fpath = os.path.join(args.output, fname)
-        seg.export(fpath, format="mp3", bitrate=args.bitrate)
-        export_paths.append(fpath)
-        rows.append((idx, mmss(st), mmss(en), round(len(seg)/1000,3), fname))
+        csv_header = ["Verse", "Start", "End", "Duration(s)", "File"]
 
     if args.csv_out:
         with open(args.csv_out, "w", newline="", encoding="utf-8") as f:
             w = csv.writer(f)
-            w.writerow(["Verse","Start","End","Duration(s)","File"])
-            for r in rows:
+            if csv_header:
+                w.writerow(csv_header)
+            for r in csv_rows:
                 w.writerow(r)
 
     if args.make_zip:
         zip_path = os.path.join(args.output, "verses.zip")
         with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
             for p in export_paths:
-                zf.write(p, arcname=os.path.basename(p))
+                arcname = os.path.relpath(p, args.output)
+                zf.write(p, arcname=arcname)
 
     print(f"Done. Wrote {len(export_paths)} files to: {args.output}")
     if args.make_zip:


### PR DESCRIPTION
## Summary
- add Excel workbook ingestion support with sanitized per-sheet outputs and verse naming
- expand helper utilities for parsing Excel timestamps and include structured CSV/zip exports
- document the new workflow and declare the openpyxl dependency

## Testing
- python -m compileall split_verses.py

------
https://chatgpt.com/codex/tasks/task_e_68ef2ecf685083268c7f0a477402e87e