### PR TITLE
Add support for processing multiple audio files with Excel timestamps

### DIFF
--- a/README_split_verses.md
+++ b/README_split_verses.md
@@ -94,6 +94,39 @@ Each sheet is exported to its own subdirectory (named after the sheet). File nam
 - `--fade_out`: fade-out in milliseconds, default `10`
 - `--zip`     : also creates `verses.zip` in the output directory
 - `--csv`     : write timings CSV to given path
+- `--input-list`: text file describing audio sources used with `--timestamps-excel`
+
+### Using `--input-list`
+
+When you have an Excel workbook that contains timings for several audio
+files, you can process them all in one run by supplying `--input-list` in
+addition to `--timestamps-excel`.
+
+Create a UTF-8 text file (for example `audio_sources.txt`) with one entry
+per line. Each line can be either just a path to an audio file, applied in
+order to sheets without an explicit mapping, **or** a sheet name followed by
+the path, separated by a comma, tab, or `|`:
+
+```text
+# Lines starting with # are ignored
+Chapter 1,chapter1.mp3
+Chapter 2,chapter2.mp3
+Bonus Material|extras/bonus.mp3
+```
+
+You can mix the two styles. Relative paths are resolved relative to the list
+file location, so the example above looks for `chapter1.mp3` next to
+`audio_sources.txt` and `extras/bonus.mp3` in the `extras` subdirectory. If a
+sheet name is repeated in the list, the last entry wins.
+
+Run the tool with:
+
+```bash
+python split_verses.py --timestamps-excel chapters.xlsx --input-list audio_sources.txt -o out
+```
+
+Each sheet uses its associated audio file while retaining all other
+behaviour (ZIP/CSV output, fades, etc.).
 
 ## License
 MIT — use freely in your project.


### PR DESCRIPTION
## Summary
- add an --input-list option so multiple audio sources can be paired with Excel sheets in one run
- allow Excel parsing without a single total duration and clamp segments per audio file
- document the new workflow for supplying a list of input files

## Testing
- python -m compileall split_verses.py

------
https://chatgpt.com/codex/tasks/task_e_68ef344522208326ae6c6dac312e3929